### PR TITLE
feat(ante): Add ante handler for EVM transactions and implement some test fixes

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -1,19 +1,18 @@
 package app
 
 import (
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
-	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
-
 	errorsmod "cosmossdk.io/errors"
 	txsigning "cosmossdk.io/x/tx/signing"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	ante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
+	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	evmosanteinterfaces "github.com/evmos/os/ante/interfaces"
 
 	osmoante "github.com/osmosis-labs/osmosis/v25/ante"
@@ -151,6 +150,11 @@ func NewHandlerOptions(
 // transaction-level processing (e.g. fee payment, signature verification) before
 // being passed onto it's respective handler.
 func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
+	// TODO: check if this is fine, prior the mempool decorator was always instantiated, which was setting the
+	// backup file path.
+	// Now, since the decorators are only instantiated for non-EVM transactions, we have to manually call this here.
+	options.txFeesKeeper.SetBackupFilePath()
+
 	return func(
 		ctx sdk.Context, tx sdk.Tx, sim bool,
 	) (newCtx sdk.Context, err error) {

--- a/app/ante.go
+++ b/app/ante.go
@@ -62,14 +62,9 @@ type HandlerOptions struct {
 	maxGasWanted        uint64
 }
 
-// TODO: check rest of items
 func (options HandlerOptions) Validate() error {
 	if options.appOpts == nil {
 		return errorsmod.Wrap(errortypes.ErrLogic, "appOpts cannot be nil")
-	}
-
-	if options.wasmConfig.SimulationGasLimit == nil {
-		return errorsmod.Wrap(errortypes.ErrLogic, "wasmConfig.SimulationGasLimit cannot be 0")
 	}
 
 	if options.txCounterStoreKey == nil {

--- a/app/ante.go
+++ b/app/ante.go
@@ -6,12 +6,15 @@ import (
 	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 
+	errorsmod "cosmossdk.io/errors"
 	txsigning "cosmossdk.io/x/tx/signing"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	ante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	evmosanteinterfaces "github.com/evmos/os/ante/interfaces"
 
 	osmoante "github.com/osmosis-labs/osmosis/v25/ante"
 	v9 "github.com/osmosis-labs/osmosis/v25/app/upgrades/v9"
@@ -27,6 +30,10 @@ import (
 	txfeestypes "github.com/osmosis-labs/osmosis/v25/x/txfees/types"
 
 	auctionante "github.com/skip-mev/block-sdk/v2/x/auction/ante"
+
+	evmosevmante "github.com/evmos/os/ante/evm"
+	evmkeeper "github.com/evmos/os/x/evm/keeper"
+	feemarketkeeper "github.com/evmos/os/x/feemarket/keeper"
 )
 
 // BlockSDKAnteHandlerParams are the parameters necessary to configure the block-sdk antehandlers
@@ -36,16 +43,79 @@ type BlockSDKAnteHandlerParams struct {
 	txConfig      client.TxConfig
 }
 
-// Link to default ante handler used by cosmos sdk:
-// https://github.com/cosmos/cosmos-sdk/blob/v0.43.0/x/auth/ante/ante.go#L41
-// N.B. There is a sister file called `ante_no_seq.go` that is used for e2e testing.
-// It leaves out the `IncrementSequenceDecorator` which is not needed for e2e testing.
-// If you make a change here, make sure to make the same change in `ante_no_seq.go`.
-func NewAnteHandler(
+type HandlerOptions struct {
+	appOpts             servertypes.AppOptions
+	wasmConfig          wasmtypes.WasmConfig
+	txCounterStoreKey   corestoretypes.KVStoreService
+	accountKeeper       evmosanteinterfaces.AccountKeeper
+	smartAccountKeeper  *smartaccountkeeper.Keeper
+	bankKeeper          txfeestypes.BankKeeper
+	txFeesKeeper        *txfeeskeeper.Keeper
+	spotPriceCalculator txfeestypes.SpotPriceCalculator
+	sigGasConsumer      ante.SignatureVerificationGasConsumer
+	signModeHandler     *txsigning.HandlerMap
+	channelKeeper       *ibckeeper.Keeper
+	blockSDKParams      BlockSDKAnteHandlerParams
+	appCodec            codec.Codec
+	evmKeeper           *evmkeeper.Keeper
+	feemarketKeeper     feemarketkeeper.Keeper
+	maxGasWanted        uint64
+}
+
+// TODO: check rest of items
+func (options HandlerOptions) Validate() error {
+	if options.appOpts == nil {
+		return errorsmod.Wrap(errortypes.ErrLogic, "appOpts cannot be nil")
+	}
+
+	if options.wasmConfig.SimulationGasLimit == nil {
+		return errorsmod.Wrap(errortypes.ErrLogic, "wasmConfig.SimulationGasLimit cannot be 0")
+	}
+
+	if options.txCounterStoreKey == nil {
+		return errorsmod.Wrap(errortypes.ErrLogic, "txCounterStoreKey cannot be nil")
+	}
+
+	if options.blockSDKParams.txConfig == nil {
+		return errorsmod.Wrap(errortypes.ErrLogic, "txConfig cannot be nil")
+	}
+
+	if options.blockSDKParams.mevLane == nil {
+		return errorsmod.Wrap(errortypes.ErrLogic, "mevLane cannot be nil")
+	}
+
+	if options.smartAccountKeeper == nil {
+		return errorsmod.Wrap(errortypes.ErrLogic, "smartAccountKeeper cannot be nil")
+	}
+
+	if options.txFeesKeeper == nil {
+		return errorsmod.Wrap(errortypes.ErrLogic, "txFeesKeeper cannot be nil")
+	}
+
+	if options.sigGasConsumer == nil {
+		return errorsmod.Wrap(errortypes.ErrLogic, "sigGasConsumer cannot be nil")
+	}
+
+	if options.signModeHandler == nil {
+		return errorsmod.Wrap(errortypes.ErrLogic, "signModeHandler cannot be nil")
+	}
+
+	if options.channelKeeper == nil {
+		return errorsmod.Wrap(errortypes.ErrLogic, "channelKeeper cannot be nil")
+	}
+
+	if options.evmKeeper == nil {
+		return errorsmod.Wrap(errortypes.ErrLogic, "evmKeeper cannot be nil")
+	}
+
+	return nil
+}
+
+func NewHandlerOptions(
 	appOpts servertypes.AppOptions,
 	wasmConfig wasmtypes.WasmConfig,
 	txCounterStoreKey corestoretypes.KVStoreService,
-	accountKeeper ante.AccountKeeper,
+	accountKeeper evmosanteinterfaces.AccountKeeper,
 	smartAccountKeeper *smartaccountkeeper.Keeper,
 	bankKeeper txfeestypes.BankKeeper,
 	txFeesKeeper *txfeeskeeper.Keeper,
@@ -55,12 +125,85 @@ func NewAnteHandler(
 	channelKeeper *ibckeeper.Keeper,
 	blockSDKParams BlockSDKAnteHandlerParams,
 	appCodec codec.Codec,
-) sdk.AnteHandler {
-	mempoolFeeOptions := txfeestypes.NewMempoolFeeOptions(appOpts)
-	mempoolFeeDecorator := txfeeskeeper.NewMempoolFeeDecorator(*txFeesKeeper, mempoolFeeOptions)
-	sendblockOptions := osmoante.NewSendBlockOptions(appOpts)
-	sendblockDecorator := osmoante.NewSendBlockDecorator(sendblockOptions, appCodec)
-	deductFeeDecorator := txfeeskeeper.NewDeductFeeDecorator(*txFeesKeeper, accountKeeper, bankKeeper, nil)
+	evmKeeper *evmkeeper.Keeper,
+	feemarketKeeper feemarketkeeper.Keeper,
+	maxGasWanted uint64,
+) HandlerOptions {
+	return HandlerOptions{
+		appOpts:             appOpts,
+		wasmConfig:          wasmConfig,
+		txCounterStoreKey:   txCounterStoreKey,
+		accountKeeper:       accountKeeper,
+		smartAccountKeeper:  smartAccountKeeper,
+		bankKeeper:          bankKeeper,
+		txFeesKeeper:        txFeesKeeper,
+		spotPriceCalculator: spotPriceCalculator,
+		sigGasConsumer:      sigGasConsumer,
+		signModeHandler:     signModeHandler,
+		channelKeeper:       channelKeeper,
+		blockSDKParams:      blockSDKParams,
+		appCodec:            appCodec,
+		evmKeeper:           evmKeeper,
+		feemarketKeeper:     feemarketKeeper,
+		maxGasWanted:        maxGasWanted,
+	}
+}
+
+// NewAnteHandler returns an ante handler responsible for attempting to route an
+// Ethereum or SDK transaction to an internal ante handler for performing
+// transaction-level processing (e.g. fee payment, signature verification) before
+// being passed onto it's respective handler.
+func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
+	return func(
+		ctx sdk.Context, tx sdk.Tx, sim bool,
+	) (newCtx sdk.Context, err error) {
+		var anteHandler sdk.AnteHandler
+
+		txWithExtensions, ok := tx.(ante.HasExtensionOptionsTx)
+		if ok {
+			opts := txWithExtensions.GetExtensionOptions()
+			if len(opts) > 0 {
+				switch typeURL := opts[0].GetTypeUrl(); typeURL {
+				case "/os.evm.v1.ExtensionOptionsEthereumTx":
+					// handle as *evmtypes.MsgEthereumTx
+					anteHandler = newMonoEVMAnteHandler(options)
+				case "/os.types.v1.ExtensionOptionDynamicFeeTx":
+					// cosmos-sdk tx with dynamic fee extension
+					anteHandler = NewCosmosAnteHandler(options)
+				default:
+					return ctx, errorsmod.Wrapf(
+						errortypes.ErrUnknownExtensionOptions,
+						"rejecting tx with unsupported extension option: %s", typeURL,
+					)
+				}
+
+				return anteHandler(ctx, tx, sim)
+			}
+		}
+
+		// handle as totally normal Cosmos SDK tx
+		switch tx.(type) {
+		case sdk.Tx:
+			anteHandler = NewCosmosAnteHandler(options)
+		default:
+			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid transaction type: %T", tx)
+		}
+
+		return anteHandler(ctx, tx, sim)
+	}
+}
+
+// Link to default ante handler used by cosmos sdk:
+// https://github.com/cosmos/cosmos-sdk/blob/v0.43.0/x/auth/ante/ante.go#L41
+// N.B. There is a sister file called `ante_no_seq.go` that is used for e2e testing.
+// It leaves out the `IncrementSequenceDecorator` which is not needed for e2e testing.
+// If you make a change here, make sure to make the same change in `ante_no_seq.go`.
+func NewCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
+	mempoolFeeOptions := txfeestypes.NewMempoolFeeOptions(options.appOpts)
+	mempoolFeeDecorator := txfeeskeeper.NewMempoolFeeDecorator(*options.txFeesKeeper, mempoolFeeOptions)
+	sendblockOptions := osmoante.NewSendBlockOptions(options.appOpts)
+	sendblockDecorator := osmoante.NewSendBlockDecorator(sendblockOptions, options.appCodec)
+	deductFeeDecorator := txfeeskeeper.NewDeductFeeDecorator(*options.txFeesKeeper, options.accountKeeper, options.bankKeeper, nil)
 
 	// classicSignatureVerificationDecorator is the old flow to enable a circuit breaker
 	classicSignatureVerificationDecorator := sdk.ChainAnteDecorators(
@@ -68,40 +211,40 @@ func NewAnteHandler(
 		// We use the old pubkey decorator here to ensure that accounts work as expected,
 		// in SetPubkeyDecorator we set a pubkey in the account store, for authenticators
 		// we avoid this code path completely.
-		ante.NewSetPubKeyDecorator(accountKeeper),
-		ante.NewValidateSigCountDecorator(accountKeeper),
-		ante.NewSigGasConsumeDecorator(accountKeeper, sigGasConsumer),
-		ante.NewSigVerificationDecorator(accountKeeper, signModeHandler),
-		ante.NewIncrementSequenceDecorator(accountKeeper),
-		ibcante.NewRedundantRelayDecorator(channelKeeper),
+		ante.NewSetPubKeyDecorator(options.accountKeeper),
+		ante.NewValidateSigCountDecorator(options.accountKeeper),
+		ante.NewSigGasConsumeDecorator(options.accountKeeper, options.sigGasConsumer),
+		ante.NewSigVerificationDecorator(options.accountKeeper, options.signModeHandler),
+		ante.NewIncrementSequenceDecorator(options.accountKeeper),
+		ibcante.NewRedundantRelayDecorator(options.channelKeeper),
 		// auction module antehandler
 		auctionante.NewAuctionDecorator(
-			blockSDKParams.auctionKeeper,
-			blockSDKParams.txConfig.TxEncoder(),
-			blockSDKParams.mevLane,
+			options.blockSDKParams.auctionKeeper,
+			options.blockSDKParams.txConfig.TxEncoder(),
+			options.blockSDKParams.mevLane,
 		),
 	)
 
 	// authenticatorVerificationDecorator is the new authenticator flow that's embedded into the circuit breaker ante
 	authenticatorVerificationDecorator := sdk.ChainAnteDecorators(
-		smartaccountante.NewEmitPubKeyDecoratorEvents(accountKeeper),
-		ante.NewValidateSigCountDecorator(accountKeeper), // we can probably remove this as multisigs are not supported here
+		smartaccountante.NewEmitPubKeyDecoratorEvents(options.accountKeeper),
+		ante.NewValidateSigCountDecorator(options.accountKeeper), // we can probably remove this as multisigs are not supported here
 		// Both the signature verification, fee deduction, and gas consumption functionality
 		// is embedded in the authenticator decorator
-		smartaccountante.NewAuthenticatorDecorator(appCodec, smartAccountKeeper, accountKeeper, signModeHandler, deductFeeDecorator),
-		ante.NewIncrementSequenceDecorator(accountKeeper),
+		smartaccountante.NewAuthenticatorDecorator(options.appCodec, options.smartAccountKeeper, options.accountKeeper, options.signModeHandler, deductFeeDecorator),
+		ante.NewIncrementSequenceDecorator(options.accountKeeper),
 		// auction module antehandler
 		auctionante.NewAuctionDecorator(
-			blockSDKParams.auctionKeeper,
-			blockSDKParams.txConfig.TxEncoder(),
-			blockSDKParams.mevLane,
+			options.blockSDKParams.auctionKeeper,
+			options.blockSDKParams.txConfig.TxEncoder(),
+			options.blockSDKParams.mevLane,
 		),
 	)
 
 	return sdk.ChainAnteDecorators(
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
-		wasmkeeper.NewLimitSimulationGasDecorator(wasmConfig.SimulationGasLimit),
-		wasmkeeper.NewCountTXDecorator(txCounterStoreKey),
+		wasmkeeper.NewLimitSimulationGasDecorator(options.wasmConfig.SimulationGasLimit),
+		wasmkeeper.NewCountTXDecorator(options.txCounterStoreKey),
 		ante.NewExtensionOptionsDecorator(nil),
 		v9.MsgFilterDecorator{},
 		// Use Mempool Fee Decorator from our txfees module instead of default one from auth
@@ -110,12 +253,26 @@ func NewAnteHandler(
 		sendblockDecorator,
 		ante.NewValidateBasicDecorator(),
 		ante.TxTimeoutHeightDecorator{},
-		ante.NewValidateMemoDecorator(accountKeeper),
-		ante.NewConsumeGasForTxSizeDecorator(accountKeeper),
+		ante.NewValidateMemoDecorator(options.accountKeeper),
+		ante.NewConsumeGasForTxSizeDecorator(options.accountKeeper),
 		smartaccountante.NewCircuitBreakerDecorator(
-			smartAccountKeeper,
+			options.smartAccountKeeper,
 			authenticatorVerificationDecorator,
 			classicSignatureVerificationDecorator,
 		),
+	)
+}
+
+// newMonoEVMAnteHandler is the ante handler for EVM transactions.
+func newMonoEVMAnteHandler(options HandlerOptions) sdk.AnteHandler {
+	monoEVMDecorator := evmosevmante.NewEVMMonoDecorator(
+		options.accountKeeper,
+		options.feemarketKeeper,
+		options.evmKeeper,
+		options.maxGasWanted,
+	)
+
+	return sdk.ChainAnteDecorators(
+		monoEVMDecorator,
 	)
 }

--- a/app/ante.go
+++ b/app/ante.go
@@ -183,7 +183,7 @@ func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 			}
 		}
 
-		// handle as totally normal Cosmos SDK tx
+		// handle as normal Cosmos SDK tx
 		switch tx.(type) {
 		case sdk.Tx:
 			anteHandler = NewCosmosAnteHandler(options)
@@ -195,11 +195,10 @@ func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 	}
 }
 
+// NewCosmosAnteHandler creates the decorator chain used for Cosmos transactions.
+//
 // Link to default ante handler used by cosmos sdk:
 // https://github.com/cosmos/cosmos-sdk/blob/v0.43.0/x/auth/ante/ante.go#L41
-// N.B. There is a sister file called `ante_no_seq.go` that is used for e2e testing.
-// It leaves out the `IncrementSequenceDecorator` which is not needed for e2e testing.
-// If you make a change here, make sure to make the same change in `ante_no_seq.go`.
 func NewCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 	mempoolFeeOptions := txfeestypes.NewMempoolFeeOptions(options.appOpts)
 	mempoolFeeDecorator := txfeeskeeper.NewMempoolFeeDecorator(*options.txFeesKeeper, mempoolFeeOptions)

--- a/app/apptesting/test_suite.go
+++ b/app/apptesting/test_suite.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/app"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 
 	"github.com/osmosis-labs/osmosis/v25/x/gamm/pool-models/balancer"
 	gammtypes "github.com/osmosis-labs/osmosis/v25/x/gamm/types"
@@ -233,7 +234,7 @@ func (s *KeeperTestHelper) SetupWithLevelDb() func() {
 }
 
 func (s *KeeperTestHelper) setupGeneral() {
-	s.setupGeneralCustomChainId("osmosis-1")
+	s.setupGeneralCustomChainId(osmoconstants.MainnetChainID)
 }
 
 func (s *KeeperTestHelper) setupGeneralCustomChainId(chainId string) {

--- a/app/config.go
+++ b/app/config.go
@@ -18,7 +18,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/osmosis-labs/osmosis/osmoutils"
-	"github.com/osmosis-labs/osmosis/v25/app/keepers"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 )
 
 type OTELConfig struct {
@@ -30,6 +30,8 @@ type OTELConfig struct {
 // testing requirements.
 func DefaultConfig() network.Config {
 	encCfg := MakeEncodingConfig()
+	testChainID := fmt.Sprintf("osmosistest_%d-%d", osmoconstants.EIP155ChainID, osmoconstants.ChainIDSuffix)
+	genesisState := NewDefaultGenesisState()
 
 	return network.Config{
 		Codec:             encCfg.Marshaler,
@@ -37,10 +39,10 @@ func DefaultConfig() network.Config {
 		LegacyAmino:       encCfg.Amino,
 		InterfaceRegistry: encCfg.InterfaceRegistry,
 		AccountRetriever:  authtypes.AccountRetriever{},
-		AppConstructor:    NewAppConstructor("osmosis-code-test"),
-		GenesisState:      keepers.AppModuleBasics.DefaultGenesis(encCfg.Marshaler),
+		AppConstructor:    NewAppConstructor(testChainID),
+		GenesisState:      genesisState,
 		TimeoutCommit:     1 * time.Second / 2,
-		ChainID:           "osmosis-code-test",
+		ChainID:           testChainID,
 		NumValidators:     1,
 		BondDenom:         sdk.DefaultBondDenom,
 		MinGasPrices:      fmt.Sprintf("0.000006%s", sdk.DefaultBondDenom),

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -6,6 +6,8 @@ import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
 	"github.com/osmosis-labs/osmosis/v25/app/keepers"
+
+	evmtypes "github.com/evmos/os/x/evm/types"
 )
 
 // The genesis state of the blockchain is represented here as a map of raw json
@@ -51,6 +53,11 @@ func NewDefaultGenesisState() GenesisState {
 		},
 	}
 	gen[wasmtypes.ModuleName] = encCfg.Marshaler.MustMarshalJSON(&wasmGen)
+
+	evmGen := evmtypes.DefaultGenesisState()
+	evmGen.Params.EvmDenom = "uosmo"
+	gen[evmtypes.ModuleName] = encCfg.Marshaler.MustMarshalJSON(evmGen)
+
 	defaultGenesisState = cloneGenesisState(gen)
 	return gen
 }

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -679,7 +679,7 @@ func (appKeepers *AppKeepers) InitEvmOSKeepers(
 	appKeepers.EVMKeeper = evmkeeper.NewKeeper(
 		appCodec,
 		appKeepers.keys[evmtypes.StoreKey],
-		appKeepers.tkeys[evmtypes.ModuleName],
+		appKeepers.tkeys[evmtypes.TransientKey],
 		authtypes.NewModuleAddress(govtypes.ModuleName),
 		appKeepers.AccountKeeper,
 		appKeepers.BankKeeper,

--- a/app/keepers/modules.go
+++ b/app/keepers/modules.go
@@ -9,6 +9,8 @@ import (
 	transfer "github.com/cosmos/ibc-go/v8/modules/apps/transfer"
 	ibc "github.com/cosmos/ibc-go/v8/modules/core"
 	tendermint "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
+	"github.com/evmos/os/x/evm"
+	evmosfeemarket "github.com/evmos/os/x/feemarket"
 
 	"cosmossdk.io/x/evidence"
 	"cosmossdk.io/x/upgrade"
@@ -133,4 +135,7 @@ var AppModuleBasics = module.NewBasicManager(
 	tendermint.AppModuleBasic{},
 	auction.AppModuleBasic{},
 	smartaccount.AppModuleBasic{},
+	// evmOS modules
+	evm.AppModuleBasic{},
+	evmosfeemarket.AppModuleBasic{},
 )

--- a/app/modules_test.go
+++ b/app/modules_test.go
@@ -8,12 +8,13 @@ import (
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sims "github.com/cosmos/cosmos-sdk/testutil/sims"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	"github.com/stretchr/testify/require"
 )
 
 func TestOrderEndBlockers_Determinism(t *testing.T) {
 	db := dbm.NewMemDB()
-	app := NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 5, sims.EmptyAppOptions{}, EmptyWasmOpts, baseapp.SetChainID("osmosis-1"))
+	app := NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 5, sims.EmptyAppOptions{}, EmptyWasmOpts, baseapp.SetChainID(osmoconstants.MainnetChainID))
 
 	for i := 0; i < 1000; i++ {
 		a := OrderEndBlockers(app.mm.ModuleNames())

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -11,6 +11,7 @@ import (
 	cosmosdb "github.com/cosmos/cosmos-db"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 
 	sdkmath "cosmossdk.io/math"
 	tmtypes "github.com/cometbft/cometbft/types"
@@ -118,7 +119,7 @@ var defaultGenesisStatebytes = []byte{}
 
 // SetupWithCustomHome initializes a new OsmosisApp with a custom home directory
 func SetupWithCustomHome(isCheckTx bool, dir string) *OsmosisApp {
-	return SetupWithCustomHomeAndChainId(isCheckTx, dir, "osmosis-1")
+	return SetupWithCustomHomeAndChainId(isCheckTx, dir, osmoconstants.MainnetChainID)
 }
 
 func SetupWithCustomHomeAndChainId(isCheckTx bool, dir, chainId string) *OsmosisApp {
@@ -166,7 +167,7 @@ func SetupTestingAppWithLevelDb(isCheckTx bool) (app *OsmosisApp, cleanupFn func
 	if err != nil {
 		panic(err)
 	}
-	app = NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 5, sims.EmptyAppOptions{}, EmptyWasmOpts, baseapp.SetChainID("osmosis-1"))
+	app = NewOsmosisApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, 5, sims.EmptyAppOptions{}, EmptyWasmOpts, baseapp.SetChainID(osmoconstants.MainnetChainID))
 	if !isCheckTx {
 		genesisState := GenesisStateWithValSet(app)
 		stateBytes, err := json.MarshalIndent(genesisState, "", " ")
@@ -179,7 +180,7 @@ func SetupTestingAppWithLevelDb(isCheckTx bool) (app *OsmosisApp, cleanupFn func
 				Validators:      []abci.ValidatorUpdate{},
 				ConsensusParams: sims.DefaultConsensusParams,
 				AppStateBytes:   stateBytes,
-				ChainId:         "osmosis-1",
+				ChainId:         osmoconstants.MainnetChainID,
 			},
 		)
 		if err != nil {

--- a/app/upgrades/v17/upgrades.go
+++ b/app/upgrades/v17/upgrades.go
@@ -38,12 +38,15 @@ type clPoolCreationInfo struct {
 }
 
 const (
-	mainnetChainID = osmoconstants.MainnetChainID
-	e2eChainA      = "osmo-test-a"
-	e2eChainB      = "osmo-test-b"
+	e2eChainA = "osmo-test-a"
+	e2eChainB = "osmo-test-b"
 )
 
-var notEnoughLiquidityForSwapErr = errorsmod.Wrapf(gammtypes.ErrInvalidMathApprox, "token amount must be positive")
+var (
+	mainnetChainID = osmoconstants.MainnetChainID
+
+	notEnoughLiquidityForSwapErr = errorsmod.Wrapf(gammtypes.ErrInvalidMathApprox, "token amount must be positive")
+)
 
 func CreateUpgradeHandler(
 	mm *module.Manager,

--- a/app/upgrades/v17/upgrades.go
+++ b/app/upgrades/v17/upgrades.go
@@ -16,6 +16,7 @@ import (
 
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	cltypes "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity/types"
 	gammtypes "github.com/osmosis-labs/osmosis/v25/x/gamm/types"
 	gammmigration "github.com/osmosis-labs/osmosis/v25/x/gamm/types/migration"
@@ -37,7 +38,7 @@ type clPoolCreationInfo struct {
 }
 
 const (
-	mainnetChainID = "osmosis-1"
+	mainnetChainID = osmoconstants.MainnetChainID
 	e2eChainA      = "osmo-test-a"
 	e2eChainB      = "osmo-test-b"
 )

--- a/app/upgrades/v21/constants.go
+++ b/app/upgrades/v21/constants.go
@@ -1,17 +1,22 @@
 package v21
 
 import (
-	"github.com/osmosis-labs/osmosis/v25/app/upgrades"
+	"fmt"
 
 	store "cosmossdk.io/store/types"
 	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	"github.com/osmosis-labs/osmosis/v25/app/upgrades"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 )
 
 // UpgradeName defines the on-chain upgrade name for the Osmosis v21 upgrade.
 const (
-	UpgradeName    = "v21"
-	TestingChainId = "testing-chain-id"
+	UpgradeName = "v21"
+)
+
+var (
+	TestingChainId = fmt.Sprintf("testingchain_%d-%d", osmoconstants.EIP155ChainID, osmoconstants.ChainIDSuffix)
 )
 
 var Upgrade = upgrades.Upgrade{

--- a/app/upgrades/v23/upgrades.go
+++ b/app/upgrades/v23/upgrades.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	mainnetChainID = osmoconstants.MainnetChainID
 	// Edgenet is to function exactly the samas mainnet, and expected
 	// to be state-exported from mainnet state.
 	edgenetChainID = "edgenet"
@@ -30,6 +29,10 @@ const (
 	// E2E chain IDs which we expect to migrate all pools similar to testnet.
 	e2eChainIDA = "osmo-test-a"
 	e2eChainIDB = "osmo-test-b"
+)
+
+var (
+	mainnetChainID = osmoconstants.MainnetChainID
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v23/upgrades.go
+++ b/app/upgrades/v23/upgrades.go
@@ -14,12 +14,13 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v25/app/keepers"
 	"github.com/osmosis-labs/osmosis/v25/app/upgrades"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	concentratedliquidity "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity"
 	concentratedtypes "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity/types"
 )
 
 const (
-	mainnetChainID = "osmosis-1"
+	mainnetChainID = osmoconstants.MainnetChainID
 	// Edgenet is to function exactly the samas mainnet, and expected
 	// to be state-exported from mainnet state.
 	edgenetChainID = "edgenet"

--- a/app/upgrades/v24/upgrades.go
+++ b/app/upgrades/v24/upgrades.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v25/app/keepers"
 	"github.com/osmosis-labs/osmosis/v25/app/upgrades"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	concentratedliquidity "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity"
 	concentratedtypes "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity/types"
 	cwpooltypes "github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/types"
@@ -19,7 +20,7 @@ import (
 )
 
 const (
-	mainnetChainID = "osmosis-1"
+	mainnetChainID = osmoconstants.MainnetChainID
 	// Edgenet is to function exactly the same as mainnet, and expected
 	// to be state-exported from mainnet state.
 	edgenetChainID = "edgenet"

--- a/app/upgrades/v24/upgrades.go
+++ b/app/upgrades/v24/upgrades.go
@@ -20,10 +20,13 @@ import (
 )
 
 const (
-	mainnetChainID = osmoconstants.MainnetChainID
 	// Edgenet is to function exactly the same as mainnet, and expected
 	// to be state-exported from mainnet state.
 	edgenetChainID = "edgenet"
+)
+
+var (
+	mainnetChainID = osmoconstants.MainnetChainID
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v25/upgrades.go
+++ b/app/upgrades/v25/upgrades.go
@@ -25,7 +25,6 @@ import (
 )
 
 const (
-	mainnetChainID = osmoconstants.MainnetChainID
 	// Edgenet is to function exactly the same as mainnet, and expected
 	// to be state-exported from mainnet state.
 	edgenetChainID = "edgenet"
@@ -35,6 +34,10 @@ const (
 	// E2E chain IDs which we expect to migrate all pools similar to testnet.
 	e2eChainIDA = "osmo-test-a"
 	e2eChainIDB = "osmo-test-b"
+)
+
+var (
+	mainnetChainID = osmoconstants.MainnetChainID
 )
 
 func CreateUpgradeHandler(

--- a/app/upgrades/v25/upgrades.go
+++ b/app/upgrades/v25/upgrades.go
@@ -18,13 +18,14 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v25/app/keepers"
 	"github.com/osmosis-labs/osmosis/v25/app/upgrades"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 
 	concentratedliquidity "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity"
 	concentratedtypes "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity/types"
 )
 
 const (
-	mainnetChainID = "osmosis-1"
+	mainnetChainID = osmoconstants.MainnetChainID
 	// Edgenet is to function exactly the same as mainnet, and expected
 	// to be state-exported from mainnet state.
 	edgenetChainID = "edgenet"

--- a/app/upgrades/v4/upgrade_test.go
+++ b/app/upgrades/v4/upgrade_test.go
@@ -21,6 +21,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	appparams "github.com/osmosis-labs/osmosis/v25/app/params"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 )
 
 type UpgradeTestSuite struct {
@@ -33,7 +34,7 @@ type UpgradeTestSuite struct {
 
 func (s *UpgradeTestSuite) SetupTest() {
 	s.app = app.Setup(false)
-	s.ctx = s.app.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: "osmosis-1", Time: time.Now().UTC()})
+	s.ctx = s.app.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: osmoconstants.MainnetChainID, Time: time.Now().UTC()})
 	s.preModule = upgrade.NewAppModule(s.app.UpgradeKeeper, addresscodec.NewBech32Codec("osmo"))
 }
 

--- a/app/upgrades/v8/forks.go
+++ b/app/upgrades/v8/forks.go
@@ -2,6 +2,7 @@ package v8
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 
 	"github.com/osmosis-labs/osmosis/v25/app/keepers"
 )
@@ -11,7 +12,7 @@ import (
 func RunForkLogic(ctx sdk.Context, appKeepers *keepers.AppKeepers) {
 	// Only proceed with v8 for mainnet, testnets need not adjust their pool incentives or unbonding.
 	// https://github.com/osmosis-labs/osmosis/issues/1609
-	if ctx.ChainID() != "osmosis-1" {
+	if ctx.ChainID() != osmoconstants.MainnetChainID {
 		return
 	}
 

--- a/cmd/osmosisd/cmd/change_environment.go
+++ b/cmd/osmosisd/cmd/change_environment.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/osmosis-labs/osmosis/v25/app"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 )
 
 const (
@@ -109,7 +110,7 @@ func environmentNameToPath(environmentName string) (string, error) {
 func clientSettingsFromEnv(cmd *cobra.Command, environmentName, chainId string) error {
 	envConfigs := map[string]map[string]string{
 		EnvMainnet: {
-			flags.FlagChainID:       "osmosis-1",
+			flags.FlagChainID:       osmoconstants.MainnetChainID,
 			flags.FlagNode:          "https://rpc.osmosis.zone:443",
 			flags.FlagBroadcastMode: "block",
 		},

--- a/cmd/osmosisd/cmd/init.go
+++ b/cmd/osmosisd/cmd/init.go
@@ -31,6 +31,7 @@ import (
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 
 	"github.com/osmosis-labs/osmosis/v25/app"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 )
 
 const (
@@ -156,7 +157,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			}
 
 			var toPrint printInfo
-			isMainnet := chainID == "" || chainID == "osmosis-1"
+			isMainnet := chainID == "" || chainID == osmoconstants.MainnetChainID
 			genesisFileDownloadFailed := false
 
 			if isMainnet {
@@ -172,7 +173,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 					chainID = fmt.Sprintf("test-chain-%v", tmrand.Str(6))
 				} else {
 					// Set chainID to osmosis-1 in the case of a blank chainID
-					chainID = "osmosis-1"
+					chainID = osmoconstants.MainnetChainID
 
 					// We dont print the app state for mainnet nodes because it's massive
 					fmt.Println("Not printing app state for mainnet node due to verbosity")

--- a/cmd/osmosisd/cmd/root.go
+++ b/cmd/osmosisd/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/app/params"
 	v23 "github.com/osmosis-labs/osmosis/v25/app/upgrades/v23" // should be automated to be updated to current version every upgrade
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	"github.com/osmosis-labs/osmosis/v25/ingest/indexer"
 	"github.com/osmosis-labs/osmosis/v25/ingest/sqs"
 
@@ -162,7 +163,7 @@ var (
 var (
 	//go:embed "osmosis-1-assetlist.json" "osmo-test-5-assetlist.json"
 	assetFS   embed.FS
-	mainnetId = "osmosis-1"
+	mainnetId = osmoconstants.MainnetChainID
 	testnetId = "osmo-test-5"
 )
 
@@ -354,7 +355,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		WithHomeDir(homeDir).
 		WithViper("OSMOSIS")
 
-	tempApp := osmosis.NewOsmosisApp(log.NewNopLogger(), cosmosdb.NewMemDB(), nil, true, map[int64]bool{}, osmosis.DefaultNodeHome, 5, sims.EmptyAppOptions{}, osmosis.EmptyWasmOpts, baseapp.SetChainID("osmosis-1"))
+	tempApp := osmosis.NewOsmosisApp(log.NewNopLogger(), cosmosdb.NewMemDB(), nil, true, map[int64]bool{}, osmosis.DefaultNodeHome, 5, sims.EmptyAppOptions{}, osmosis.EmptyWasmOpts, baseapp.SetChainID(osmoconstants.MainnetChainID))
 
 	// Allows you to add extra params to your client.toml
 	// gas, gas-price, gas-adjustment, and human-readable-denoms

--- a/constants/chain_id.go
+++ b/constants/chain_id.go
@@ -5,9 +5,9 @@ import "fmt"
 const (
 	ChainIDPrefix = "osmosis"
 	EIP155ChainID = 9009
-	ChainIDSuffix = "1"
+	ChainIDSuffix = 1
 )
 
 var (
-	MainnetChainID = fmt.Sprintf("%s_%d-%s", ChainIDPrefix, EIP155ChainID, ChainIDSuffix)
+	MainnetChainID = fmt.Sprintf("%s_%d-%d", ChainIDPrefix, EIP155ChainID, ChainIDSuffix)
 )

--- a/constants/chain_id.go
+++ b/constants/chain_id.go
@@ -1,4 +1,13 @@
 package constants
 
-// MainnetChainID is the chain ID used in Osmosis mainnet
-const MainnetChainID = "osmosis_9009-1"
+import "fmt"
+
+const (
+	ChainIDPrefix = "osmosis"
+	EIP155ChainID = 9009
+	ChainIDSuffix = "1"
+)
+
+var (
+	MainnetChainID = fmt.Sprintf("%s_%d-%s", ChainIDPrefix, EIP155ChainID, ChainIDSuffix)
+)

--- a/constants/chain_id.go
+++ b/constants/chain_id.go
@@ -1,0 +1,4 @@
+package constants
+
+// MainnetChainID is the chain ID used in Osmosis mainnet
+const MainnetChainID = "osmosis_9009-1"

--- a/go.mod
+++ b/go.mod
@@ -327,6 +327,9 @@ exclude github.com/gogo/protobuf v1.3.3
 
 // evmOS replacements
 replace (
+	// required because it's using the CacheMultiStore.Copy() method which is not available in the original
+	github.com/CosmWasm/wasmd => github.com/MalteHerrmann/wasmd v0.50.1-0.20240925153347-c4a52206eaf9
+
 	// Point to the latest commit on the `osmo-sdkv50-evmOS-wip` branch
 	// https://github.com/MalteHerrmann/cosmos-sdk/tree/osmo-sdkv50-evmOS-wip
 	github.com/cosmos/cosmos-sdk => github.com/MalteHerrmann/cosmos-sdk v0.46.0-beta2.0.20240925100621-9a21fb6f400b

--- a/go.mod
+++ b/go.mod
@@ -288,7 +288,8 @@ replace (
 	cosmossdk.io/core => cosmossdk.io/core v0.11.0
 
 	// Needs to be replaced due to iavlFastNodeModuleWhitelist feature
-	cosmossdk.io/store => github.com/osmosis-labs/cosmos-sdk/store v0.1.0-alpha.1.0.20240509221435-b8feb2ffb728
+	// TODO: unify with replacement for MalteHerrmann fork?
+	// cosmossdk.io/store => github.com/osmosis-labs/cosmos-sdk/store v0.1.0-alpha.1.0.20240509221435-b8feb2ffb728
 
 	// Using branch osmo/v0.38.x
 	// https://github.com/osmosis-labs/cometbft/releases/tag/v0.37.4-v25-osmo-2
@@ -327,6 +328,7 @@ exclude github.com/gogo/protobuf v1.3.3
 
 // evmOS replacements
 replace (
+	cosmossdk.io/store => github.com/MalteHerrmann/cosmos-sdk/store v0.0.0-20240925100621-9a21fb6f400b
 	// required because it's using the CacheMultiStore.Copy() method which is not available in the original
 	github.com/CosmWasm/wasmd => github.com/MalteHerrmann/wasmd v0.50.1-0.20240925153347-c4a52206eaf9
 

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/cosmos/ibc-go/modules/light-clients/08-wasm v0.1.1-ibc-go-v7.3-wasmvm-v1.5
 	github.com/cosmos/ibc-go/v8 v8.5.1
 	github.com/cosmos/rosetta v0.50.9
-	github.com/evmos/os v0.0.0-20240925093013-1e43b90ab308
+	github.com/evmos/os v0.0.0-20240927075338-fdb81eba8360
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/mux v1.8.1
@@ -337,6 +337,6 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/MalteHerrmann/cosmos-sdk v0.46.0-beta2.0.20240925100621-9a21fb6f400b
 	github.com/ethereum/go-ethereum => github.com/evmos/go-ethereum v1.10.26-evmos-rc4
 
-	// local building
-	github.com/evmos/os => ../../evmos/os
+//// local building
+//github.com/evmos/os => ../../evmos/os
 )

--- a/go.mod
+++ b/go.mod
@@ -331,4 +331,7 @@ replace (
 	// https://github.com/MalteHerrmann/cosmos-sdk/tree/osmo-sdkv50-evmOS-wip
 	github.com/cosmos/cosmos-sdk => github.com/MalteHerrmann/cosmos-sdk v0.46.0-beta2.0.20240925100621-9a21fb6f400b
 	github.com/ethereum/go-ethereum => github.com/evmos/go-ethereum v1.10.26-evmos-rc4
+
+	// local building
+	github.com/evmos/os => ../../evmos/os
 )

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,6 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CosmWasm/wasmd v0.50.0 h1:NVaGqCSTRfb9UTDHJwT6nQIWcb6VjlQl88iI+u1+qjE=
-github.com/CosmWasm/wasmd v0.50.0/go.mod h1:UjmShW4l9YxaMytwJZ7IB7MWzHiynSZP3DdWrG0FRtk=
 github.com/CosmWasm/wasmvm v1.5.4 h1:Opqy65ubJ8bMsT08dn85VjRdsLJVPIAgIXif92qOMGc=
 github.com/CosmWasm/wasmvm v1.5.4/go.mod h1:Q0bSEtlktzh7W2hhEaifrFp1Erx11ckQZmjq8FLCyys=
 github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=
@@ -246,6 +244,8 @@ github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwS
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MalteHerrmann/cosmos-sdk v0.46.0-beta2.0.20240925100621-9a21fb6f400b h1:AS/sp2OPY8kjuG/Du9aR77YpiyGlRmQptEUUHRjTUkc=
 github.com/MalteHerrmann/cosmos-sdk v0.46.0-beta2.0.20240925100621-9a21fb6f400b/go.mod h1:xbI6+pKxoB9vokhcHfH6r9r/BZbVjlFM8/yPZqDDhQY=
+github.com/MalteHerrmann/wasmd v0.50.1-0.20240925153347-c4a52206eaf9 h1:yNkJDqrLEgfF1X6+HRVxtwA8zb2yAwQoAqnoluwltSY=
+github.com/MalteHerrmann/wasmd v0.50.1-0.20240925153347-c4a52206eaf9/go.mod h1:UjmShW4l9YxaMytwJZ7IB7MWzHiynSZP3DdWrG0FRtk=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -476,8 +476,6 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evmos/go-ethereum v1.10.26-evmos-rc4 h1:vwDVMScuB2KSu8ze5oWUuxm6v3bMUp6dL3PWvJNJY+I=
 github.com/evmos/go-ethereum v1.10.26-evmos-rc4/go.mod h1:/6CsT5Ceen2WPLI/oCA3xMcZ5sWMF/D46SjM/ayY0Oo=
-github.com/evmos/os v0.0.0-20240925093013-1e43b90ab308 h1:kj01AtX1Wc2+xCngVgSJAlJK7iJx88dESPdlZ418CWE=
-github.com/evmos/os v0.0.0-20240925093013-1e43b90ab308/go.mod h1:uQQyppk8z2C7Ypk/zj8/wnJSrf74rY8cXLzsD8F1tEE=
 github.com/evmos/os/example_chain v0.0.0-20240924163020-b2a4187dad50 h1:zWJYHc0WXE5YnuzYJnUzjMwuloxSz5ALCoNSzcuhKsA=
 github.com/evmos/os/example_chain v0.0.0-20240924163020-b2a4187dad50/go.mod h1:+SPMqw9wtbWO3jG02uLbLtVVjMHBldmXTN51kxbWqJ8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/go.sum
+++ b/go.sum
@@ -478,6 +478,8 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evmos/go-ethereum v1.10.26-evmos-rc4 h1:vwDVMScuB2KSu8ze5oWUuxm6v3bMUp6dL3PWvJNJY+I=
 github.com/evmos/go-ethereum v1.10.26-evmos-rc4/go.mod h1:/6CsT5Ceen2WPLI/oCA3xMcZ5sWMF/D46SjM/ayY0Oo=
+github.com/evmos/os v0.0.0-20240927075338-fdb81eba8360 h1:Nh/+VeCAJJUE0h5IK7dttHBE7baScLhDUipqmqybYi8=
+github.com/evmos/os v0.0.0-20240927075338-fdb81eba8360/go.mod h1:uQQyppk8z2C7Ypk/zj8/wnJSrf74rY8cXLzsD8F1tEE=
 github.com/evmos/os/example_chain v0.0.0-20240924163020-b2a4187dad50 h1:zWJYHc0WXE5YnuzYJnUzjMwuloxSz5ALCoNSzcuhKsA=
 github.com/evmos/os/example_chain v0.0.0-20240924163020-b2a4187dad50/go.mod h1:+SPMqw9wtbWO3jG02uLbLtVVjMHBldmXTN51kxbWqJ8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwS
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MalteHerrmann/cosmos-sdk v0.46.0-beta2.0.20240925100621-9a21fb6f400b h1:AS/sp2OPY8kjuG/Du9aR77YpiyGlRmQptEUUHRjTUkc=
 github.com/MalteHerrmann/cosmos-sdk v0.46.0-beta2.0.20240925100621-9a21fb6f400b/go.mod h1:xbI6+pKxoB9vokhcHfH6r9r/BZbVjlFM8/yPZqDDhQY=
+github.com/MalteHerrmann/cosmos-sdk/store v0.0.0-20240925100621-9a21fb6f400b h1:d+R0GN+/fUhGNFX2PwxBIc9IorzfwmZP1+tLJzpbwDk=
+github.com/MalteHerrmann/cosmos-sdk/store v0.0.0-20240925100621-9a21fb6f400b/go.mod h1:PeLWvol9p/aY4HWJOwEYIQzMRK+AM/Ph1A0saSiSH1U=
 github.com/MalteHerrmann/wasmd v0.50.1-0.20240925153347-c4a52206eaf9 h1:yNkJDqrLEgfF1X6+HRVxtwA8zb2yAwQoAqnoluwltSY=
 github.com/MalteHerrmann/wasmd v0.50.1-0.20240925153347-c4a52206eaf9/go.mod h1:UjmShW4l9YxaMytwJZ7IB7MWzHiynSZP3DdWrG0FRtk=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
@@ -949,8 +951,6 @@ github.com/ory/dockertest/v3 v3.11.0 h1:OiHcxKAvSDUwsEVh2BjxQQc/5EHz9n0va9awCtNG
 github.com/ory/dockertest/v3 v3.11.0/go.mod h1:VIPxS1gwT9NpPOrfD3rACs8Y9Z7yhzO4SB194iUDnUI=
 github.com/osmosis-labs/cometbft v0.0.0-20240510005818-6ce422c6f3d3 h1:20XJTsLdqOinrmeVyNCYVL3rfRf0yIQsJ+vvQNzWD2w=
 github.com/osmosis-labs/cometbft v0.0.0-20240510005818-6ce422c6f3d3/go.mod h1:HIyf811dFMI73IE0F7RrnY/Fr+d1+HuJAgtkEpQjCMY=
-github.com/osmosis-labs/cosmos-sdk/store v0.1.0-alpha.1.0.20240509221435-b8feb2ffb728 h1:AMz4HWC+WA/MwBQdsb11yIF9ForIvSLYYVy/jyhJ3/I=
-github.com/osmosis-labs/cosmos-sdk/store v0.1.0-alpha.1.0.20240509221435-b8feb2ffb728/go.mod h1:gjE3DZe4t/+VeIk6CmrouyqiuDbZ7QOVDDq3nLqBTpg=
 github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3 h1:YlmchqTmlwdWSmrRmXKR+PcU96ntOd8u10vTaTZdcNY=
 github.com/osmosis-labs/go-mutesting v0.0.0-20221208041716-b43bcd97b3b3/go.mod h1:lV6KnqXYD/ayTe7310MHtM3I2q8Z6bBfMAi+bhwPYtI=
 github.com/osmosis-labs/osmosis/osmomath v0.0.12-0.20240517165907-1625703bc16d h1:Wbf/4tR1ibsQWiBPBcAKS54eipmKGoC2bFp9rxxhnQQ=

--- a/go.work
+++ b/go.work
@@ -14,8 +14,10 @@ use ./x/epochs
 
 replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.16.5
 
-replace github.com/cosmos/cosmos-sdk => /Users/malte/dev/osmosis-labs/cosmos-sdk
+replace github.com/cosmos/cosmos-sdk => github.com/MalteHerrmann/cosmos-sdk v0.46.0-beta2.0.20240925100621-9a21fb6f400b
 
 replace cosmossdk.io/store => /Users/malte/dev/osmosis-labs/cosmos-sdk/store
 
 replace github.com/ethereum/go-ethereum => github.com/evmos/go-ethereum v1.10.26-evmos-rc4
+
+replace github.com/CosmWasm/wasmd => github.com/MalteHerrmann/wasmd v0.50.1-0.20240925153347-c4a52206eaf9

--- a/go.work
+++ b/go.work
@@ -16,8 +16,8 @@ replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.16.5
 
 replace github.com/cosmos/cosmos-sdk => github.com/MalteHerrmann/cosmos-sdk v0.46.0-beta2.0.20240925100621-9a21fb6f400b
 
-replace cosmossdk.io/store => /Users/malte/dev/osmosis-labs/cosmos-sdk/store
-
 replace github.com/ethereum/go-ethereum => github.com/evmos/go-ethereum v1.10.26-evmos-rc4
 
 replace github.com/CosmWasm/wasmd => github.com/MalteHerrmann/wasmd v0.50.1-0.20240925153347-c4a52206eaf9
+
+replace cosmossdk.io/store => github.com/MalteHerrmann/cosmos-sdk/store v0.0.0-20240925100621-9a21fb6f400b

--- a/simulation/executor/legacyconfig.go
+++ b/simulation/executor/legacyconfig.go
@@ -11,11 +11,12 @@ import (
 	cosmosdb "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	"github.com/osmosis-labs/osmosis/v25/simulation/executor/internal/stats"
 	"github.com/osmosis-labs/osmosis/v25/simulation/simtypes/simlogger"
 )
 
-const SimAppChainID = "osmosis-test"
+var SimAppChainID = fmt.Sprintf("osmosissimtest_%d-%d", osmoconstants.EIP155ChainID, osmoconstants.ChainIDSuffix)
 
 // List of available flags for the simulator
 var (

--- a/tests/ibc-hooks/ibc_middleware_test.go
+++ b/tests/ibc-hooks/ibc_middleware_test.go
@@ -291,7 +291,18 @@ func (suite *HooksTestSuite) TestOnRecvPacketHooks() {
 			trace = transfertypes.ParseDenomTrace(sdk.DefaultBondDenom)
 
 			// send coin from chainA to chainB
-			transferMsg := transfertypes.NewMsgTransfer(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, sdk.NewCoin(trace.IBCDenom(), amount), suite.chainA.SenderAccount.GetAddress().String(), receiver, clienttypes.NewHeight(1, 110), 0, "")
+			transferMsg := transfertypes.NewMsgTransfer(
+				path.EndpointA.ChannelConfig.PortID,
+				path.EndpointA.ChannelID,
+				sdk.NewCoin(trace.IBCDenom(), amount),
+				suite.chainA.SenderAccount.GetAddress().String(),
+				receiver,
+				// TODO: why was it required to adjust this to pass the test?
+				clienttypes.NewHeight(2, 110),
+				0,
+				"",
+			)
+
 			_, err := suite.chainA.SendMsgs(transferMsg)
 			suite.Require().NoError(err) // message committed
 
@@ -542,12 +553,13 @@ func (suite *HooksTestSuite) TestFundTracking() {
 // custom MsgTransfer constructor that supports Memo
 func NewMsgTransfer(token sdk.Coin, sender, receiver, channel, memo string) *transfertypes.MsgTransfer {
 	return &transfertypes.MsgTransfer{
-		SourcePort:       "transfer",
-		SourceChannel:    channel,
-		Token:            token,
-		Sender:           sender,
-		Receiver:         receiver,
-		TimeoutHeight:    clienttypes.NewHeight(1, 500),
+		SourcePort:    "transfer",
+		SourceChannel: channel,
+		Token:         token,
+		Sender:        sender,
+		Receiver:      receiver,
+		// TODO: check why this timeout number had to be adjusted
+		TimeoutHeight:    clienttypes.NewHeight(3, 500),
 		TimeoutTimestamp: 0,
 		Memo:             memo,
 	}

--- a/tests/ibc-hooks/ibc_middleware_test.go
+++ b/tests/ibc-hooks/ibc_middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
+
 	appparams "github.com/osmosis-labs/osmosis/v25/app/params"
 
 	"github.com/tidwall/gjson"
@@ -77,15 +78,15 @@ func (suite *HooksTestSuite) SetupTest() {
 
 	suite.Setup()
 	ibctesting.DefaultTestingAppInit = osmosisibctesting.SetupTestingApp
-	suite.coordinator = ibctesting.NewCoordinator(suite.T(), 3)
+	suite.coordinator = osmosisibctesting.NewCoordinator(suite.T(), 3)
 	suite.chainA = &osmosisibctesting.TestChain{
-		TestChain: suite.coordinator.GetChain(ibctesting.GetChainID(1)),
+		TestChain: suite.coordinator.GetChain(osmosisibctesting.GetOsmosisTestingChainID(1)),
 	}
 	suite.chainB = &osmosisibctesting.TestChain{
-		TestChain: suite.coordinator.GetChain(ibctesting.GetChainID(2)),
+		TestChain: suite.coordinator.GetChain(osmosisibctesting.GetOsmosisTestingChainID(2)),
 	}
 	suite.chainC = &osmosisibctesting.TestChain{
-		TestChain: suite.coordinator.GetChain(ibctesting.GetChainID(3)),
+		TestChain: suite.coordinator.GetChain(osmosisibctesting.GetOsmosisTestingChainID(3)),
 	}
 	err := suite.chainA.MoveEpochsToTheFuture()
 	suite.Require().NoError(err)

--- a/tests/localosmosis/scripts/setup.sh
+++ b/tests/localosmosis/scripts/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CHAIN_ID=localosmosis
+CHAIN_ID="localosmosis_9009-1"
 OSMOSIS_HOME=$HOME/.osmosisd
 CONFIG_FOLDER=$OSMOSIS_HOME/config
 MONIKER=val
@@ -83,6 +83,9 @@ edit_genesis () {
 
     # Update concentrated-liquidity (enable pool creation)
     dasel put -t bool -f $GENESIS '.app_state.concentratedliquidity.params.is_permissionless_pool_creation_enabled' -v true
+
+    # Update evm denom
+    dasel put -t string -f $GENESIS '.app_state.evm.params.evm_denom' -v "uosmo"
 }
 
 add_genesis_accounts () {

--- a/tests/osmosisibctesting/chain.go
+++ b/tests/osmosisibctesting/chain.go
@@ -39,7 +39,7 @@ type TestChain struct {
 
 // GetOsmosisTestingChainID returns the chainID used for the provided index.
 func GetOsmosisTestingChainID(index int) string {
-	return fmt.Sprintf("%s-test_%d-%d", osmoconstants.ChainIDPrefix, osmoconstants.EIP155ChainID, index)
+	return fmt.Sprintf("%stest_%d-%d", osmoconstants.ChainIDPrefix, osmoconstants.EIP155ChainID, index)
 }
 
 func SetupTestingApp() (ibctesting.TestingApp, map[string]json.RawMessage) {

--- a/tests/osmosisibctesting/chain.go
+++ b/tests/osmosisibctesting/chain.go
@@ -17,6 +17,7 @@ import (
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	smartaccounttypes "github.com/osmosis-labs/osmosis/v25/x/smart-account/types"
 
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
@@ -34,6 +35,11 @@ const SimAppChainID = "simulation-app"
 
 type TestChain struct {
 	*ibctesting.TestChain
+}
+
+// GetOsmosisTestingChainID returns the chainID used for the provided index.
+func GetOsmosisTestingChainID(index int) string {
+	return fmt.Sprintf("%s-test_%d-%d", osmoconstants.ChainIDPrefix, osmoconstants.EIP155ChainID, index)
 }
 
 func SetupTestingApp() (ibctesting.TestingApp, map[string]json.RawMessage) {

--- a/tests/osmosisibctesting/coordinator.go
+++ b/tests/osmosisibctesting/coordinator.go
@@ -1,0 +1,30 @@
+package osmosisibctesting
+
+import (
+	"testing"
+	"time"
+
+	ibctesting "github.com/cosmos/ibc-go/v8/testing"
+)
+
+var (
+	globalStartTime = time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
+)
+
+// NewCoordinator initializes Coordinator with N TestChain's
+func NewCoordinator(t *testing.T, n int) *ibctesting.Coordinator {
+	t.Helper()
+	chains := make(map[string]*ibctesting.TestChain)
+	coord := &ibctesting.Coordinator{
+		T:           t,
+		CurrentTime: globalStartTime,
+	}
+
+	for i := 1; i <= n; i++ {
+		chainID := GetOsmosisTestingChainID(i)
+		chains[chainID] = ibctesting.NewTestChain(t, coord, chainID)
+	}
+	coord.Chains = chains
+
+	return coord
+}

--- a/wasmbinding/query_plugin_test.go
+++ b/wasmbinding/query_plugin_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v25/app"
 	appparams "github.com/osmosis-labs/osmosis/v25/app/params"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	lockuptypes "github.com/osmosis-labs/osmosis/v25/x/lockup/types"
 	epochtypes "github.com/osmosis-labs/osmosis/x/epochs/types"
 
@@ -40,7 +41,7 @@ type StargateTestSuite struct {
 
 func (suite *StargateTestSuite) SetupTest() {
 	suite.app = app.Setup(false)
-	suite.ctx = suite.app.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: "osmosis-1", Time: time.Now().UTC()})
+	suite.ctx = suite.app.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: osmoconstants.MainnetChainID, Time: time.Now().UTC()})
 }
 
 func TestStargateTestSuite(t *testing.T) {

--- a/wasmbinding/test/helpers_test.go
+++ b/wasmbinding/test/helpers_test.go
@@ -16,11 +16,12 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/app"
 	appparams "github.com/osmosis-labs/osmosis/v25/app/params"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 )
 
 func CreateTestInput() (*app.OsmosisApp, sdk.Context) {
 	osmosis := app.Setup(false)
-	ctx := osmosis.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: "osmosis-1", Time: time.Now().UTC()})
+	ctx := osmosis.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: osmoconstants.MainnetChainID, Time: time.Now().UTC()})
 	return osmosis, ctx
 }
 

--- a/x/epochs/keeper/keeper_test.go
+++ b/x/epochs/keeper/keeper_test.go
@@ -6,14 +6,14 @@ import (
 
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	cdcutil "github.com/cosmos/cosmos-sdk/codec/testutil"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
 	"github.com/stretchr/testify/suite"
 
-	cdcutil "github.com/cosmos/cosmos-sdk/codec/testutil"
-
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	epochskeeper "github.com/osmosis-labs/osmosis/x/epochs/keeper"
 	"github.com/osmosis-labs/osmosis/x/epochs/types"
 )
@@ -51,7 +51,7 @@ func Setup() (sdk.Context, *epochskeeper.Keeper) {
 	ctx := testutil.DefaultContext(epochsStoreKey, storetypes.NewTransientStoreKey("transient_test"))
 	epochsKeeper := epochskeeper.NewKeeper(epochsStoreKey)
 	epochsKeeper = epochsKeeper.SetHooks(types.NewMultiEpochHooks())
-	ctx.WithBlockHeight(1).WithChainID("osmosis-1").WithBlockTime(time.Now().UTC())
+	ctx.WithBlockHeight(1).WithChainID(osmoconstants.MainnetChainID).WithBlockTime(time.Now().UTC())
 	epochsKeeper.InitGenesis(ctx, *types.DefaultGenesis())
 	SetEpochStartTime(ctx, epochsKeeper)
 	return ctx, epochsKeeper

--- a/x/ibc-rate-limit/ibc_middleware_test.go
+++ b/x/ibc-rate-limit/ibc_middleware_test.go
@@ -2,12 +2,13 @@ package ibc_rate_limit_test
 
 import (
 	"fmt"
-	abci "github.com/cometbft/cometbft/abci/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
 	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
 
@@ -62,16 +63,16 @@ func (suite *MiddlewareTestSuite) SetupTest() {
 	txfeetypes.ConsensusMinFee = osmomath.ZeroDec()
 	suite.Setup()
 	ibctesting.DefaultTestingAppInit = osmosisibctesting.SetupTestingApp
-	suite.coordinator = ibctesting.NewCoordinator(suite.T(), 3)
+	suite.coordinator = osmosisibctesting.NewCoordinator(suite.T(), 3)
 	suite.chainA = &osmosisibctesting.TestChain{
-		TestChain: suite.coordinator.GetChain(ibctesting.GetChainID(1)),
+		TestChain: suite.coordinator.GetChain(osmosisibctesting.GetOsmosisTestingChainID(1)),
 	}
 	// Remove epochs to prevent  minting
 	err := suite.chainA.MoveEpochsToTheFuture()
 	suite.Require().NoError(err)
 	// Create second chain
 	suite.chainB = &osmosisibctesting.TestChain{
-		TestChain: suite.coordinator.GetChain(ibctesting.GetChainID(2)),
+		TestChain: suite.coordinator.GetChain(osmosisibctesting.GetOsmosisTestingChainID(2)),
 	}
 	suite.path = NewTransferPath(suite.chainA, suite.chainB)
 	err = suite.chainB.MoveEpochsToTheFuture()
@@ -79,7 +80,7 @@ func (suite *MiddlewareTestSuite) SetupTest() {
 	suite.coordinator.Setup(suite.path)
 	// setup a third chain
 	suite.chainC = &osmosisibctesting.TestChain{
-		TestChain: suite.coordinator.GetChain(ibctesting.GetChainID(3)),
+		TestChain: suite.coordinator.GetChain(osmosisibctesting.GetOsmosisTestingChainID(3)),
 	}
 	suite.pathAC = NewTransferPath(suite.chainA, suite.chainC)
 	err = suite.chainC.MoveEpochsToTheFuture()

--- a/x/incentives/keeper/bench_test.go
+++ b/x/incentives/keeper/bench_test.go
@@ -10,6 +10,7 @@ import (
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
 	"github.com/osmosis-labs/osmosis/v25/app"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	"github.com/osmosis-labs/osmosis/v25/x/incentives/types"
 	lockuptypes "github.com/osmosis-labs/osmosis/v25/x/lockup/types"
 
@@ -75,7 +76,7 @@ func benchmarkDistributionLogic(b *testing.B, numAccts, numDenoms, numGauges, nu
 	blockStartTime := time.Now().UTC()
 	app, cleanupFn := app.SetupTestingAppWithLevelDb(false)
 	defer cleanupFn()
-	ctx := app.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: "osmosis-1", Time: blockStartTime})
+	ctx := app.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: osmoconstants.MainnetChainID, Time: blockStartTime})
 
 	r := rand.New(rand.NewSource(10))
 

--- a/x/lockup/keeper/bench_test.go
+++ b/x/lockup/keeper/bench_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/app"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	lockuptypes "github.com/osmosis-labs/osmosis/v25/x/lockup/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -39,7 +40,7 @@ func benchmarkResetLogic(b *testing.B, numLockups int) {
 
 	blockStartTime := time.Now().UTC()
 	app := app.Setup(false)
-	ctx := app.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: "osmosis-1", Time: blockStartTime})
+	ctx := app.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: osmoconstants.MainnetChainID, Time: blockStartTime})
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	numAccts := 100

--- a/x/lockup/keeper/keeper_test.go
+++ b/x/lockup/keeper/keeper_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v25/app"
 	"github.com/osmosis-labs/osmosis/v25/app/apptesting"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 	"github.com/osmosis-labs/osmosis/v25/x/lockup/keeper"
 )
 
@@ -36,7 +37,7 @@ func (s *KeeperTestSuite) SetupTest() {
 
 func (s *KeeperTestSuite) SetupTestWithLevelDb() {
 	s.App, s.cleanup = app.SetupTestingAppWithLevelDb(false)
-	s.Ctx = s.App.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: "osmosis-1", Time: time.Now().UTC()})
+	s.Ctx = s.App.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: osmoconstants.MainnetChainID, Time: time.Now().UTC()})
 }
 
 func (s *KeeperTestSuite) Cleanup() {

--- a/x/smart-account/integration_test.go
+++ b/x/smart-account/integration_test.go
@@ -57,9 +57,9 @@ func (s *AuthenticatorSuite) SetupTest() {
 	ibctesting.DefaultTestingAppInit = osmosisibctesting.SetupTestingApp
 
 	// Here we create the app using ibctesting
-	s.coordinator = ibctesting.NewCoordinator(s.T(), 1)
+	s.coordinator = osmosisibctesting.NewCoordinator(s.T(), 1)
 	s.chainA = &osmosisibctesting.TestChain{
-		TestChain: s.coordinator.GetChain(ibctesting.GetChainID(1)),
+		TestChain: s.coordinator.GetChain(osmosisibctesting.GetOsmosisTestingChainID(1)),
 	}
 	s.app = s.chainA.GetOsmosisApp()
 	s.EncodingConfig = app.MakeEncodingConfig()

--- a/x/twap/keeper_test.go
+++ b/x/twap/keeper_test.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
 
+	storetypes "cosmossdk.io/store/types"
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/osmoutils/osmoassert"
 	"github.com/osmosis-labs/osmosis/v25/app/apptesting"
@@ -42,7 +43,10 @@ func TestSuiteRun(t *testing.T) {
 func (s *TestSuite) SetupTest() {
 	s.Setup()
 	s.twapkeeper = s.App.TwapKeeper
-	s.Ctx = s.Ctx.WithBlockTime(baseTime)
+	s.Ctx = s.Ctx.
+		WithBlockTime(baseTime).
+		WithBlockGasMeter(storetypes.NewInfiniteGasMeter())
+
 	// add x/twap test specific denoms
 	poolManagerParams := s.App.PoolManagerKeeper.GetParams(s.Ctx)
 	poolManagerParams.AuthorizedQuoteDenoms = append(poolManagerParams.AuthorizedQuoteDenoms, denom0, denom1, denom2)

--- a/x/txfees/keeper/feedecorator.go
+++ b/x/txfees/keeper/feedecorator.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -34,7 +33,7 @@ type MempoolFeeDecorator struct {
 
 func NewMempoolFeeDecorator(txFeesKeeper Keeper, opts types.MempoolFeeOptions) MempoolFeeDecorator {
 	if opts.Mempool1559Enabled {
-		mempool1559.CurEipState.BackupFilePath = filepath.Join(txFeesKeeper.dataDir, mempool1559.BackupFilename)
+		txFeesKeeper.SetBackupFilePath()
 	}
 
 	return MempoolFeeDecorator{

--- a/x/txfees/keeper/keeper.go
+++ b/x/txfees/keeper/keeper.go
@@ -2,12 +2,14 @@ package keeper
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"cosmossdk.io/log"
 
 	"cosmossdk.io/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	mempool1559 "github.com/osmosis-labs/osmosis/v25/x/txfees/keeper/mempool-1559"
 	"github.com/osmosis-labs/osmosis/v25/x/txfees/types"
 
 	storetypes "cosmossdk.io/store/types"
@@ -89,4 +91,9 @@ func (k Keeper) GetFeeTokensStore(ctx sdk.Context) storetypes.KVStore {
 // GetConsParams returns the current consensus parameters from the consensus params store.
 func (k Keeper) GetConsParams(ctx sdk.Context) (*consensustypes.QueryParamsResponse, error) {
 	return k.consensusKeeper.Params(ctx, &consensustypes.QueryParamsRequest{})
+}
+
+// SetBackupFilePath sets the backup file path for the 1559 mempool
+func (k Keeper) SetBackupFilePath() {
+	mempool1559.CurEipState.BackupFilePath = filepath.Join(k.dataDir, mempool1559.BackupFilename)
 }

--- a/x/txfees/module_test.go
+++ b/x/txfees/module_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	osmosisapp "github.com/osmosis-labs/osmosis/v25/app"
+	osmoconstants "github.com/osmosis-labs/osmosis/v25/constants"
 
 	simapp "github.com/osmosis-labs/osmosis/v25/app"
 	mempool1559 "github.com/osmosis-labs/osmosis/v25/x/txfees/keeper/mempool-1559"
@@ -34,7 +35,7 @@ func TestSetBaseDenomOnInitBlock(t *testing.T) {
 			Validators:      []abci.ValidatorUpdate{},
 			ConsensusParams: sims.DefaultConsensusParams,
 			AppStateBytes:   stateBytes,
-			ChainId:         "osmosis-1",
+			ChainId:         osmoconstants.MainnetChainID,
 		},
 	)
 
@@ -45,7 +46,7 @@ func TestSetBaseDenomOnInitBlock(t *testing.T) {
 
 func TestBeginBlock(t *testing.T) {
 	app := simapp.Setup(false)
-	ctx := app.BaseApp.NewContextLegacy(false, tmproto.Header{ChainID: "osmosis-1", Height: 1})
+	ctx := app.BaseApp.NewContextLegacy(false, tmproto.Header{ChainID: osmoconstants.MainnetChainID, Height: 1})
 
 	genesisState := osmosisapp.GenesisStateWithValSet(app)
 	stateBytes, err := json.MarshalIndent(genesisState, "", " ")
@@ -58,7 +59,7 @@ func TestBeginBlock(t *testing.T) {
 			Validators:      []abci.ValidatorUpdate{},
 			ConsensusParams: sims.DefaultConsensusParams,
 			AppStateBytes:   stateBytes,
-			ChainId:         "osmosis-1",
+			ChainId:         osmoconstants.MainnetChainID,
 		},
 	)
 


### PR DESCRIPTION
## EVM Ante Handler

This PR adds the logic for the ante handling of Ethereum transactions. To discern between the respective message types, the ante handler checks for the extensions options. If it finds the `/os.evm.v1.ExtensionOptionsEthereumTx` extension, it will run the corresponding EVM ante handler, while other known extensions are handled by the Cosmos handler.

_Note:_ This PR uses the implementation of evmOS' native feemarket module for now. We are working to make the feemarket solution being able to complement Osmosis' native solution, so there is no separate module required for it. For the time being, this is added though.

_Note 2:_ We are deliberately only supporting known extension options in our usual setup of the ante handler. This should be extended for all expected options for Osmosis.

## Genesis Adjustments

The instantiation of the EVM module requires the chain denomination to be set in the EVM params, which is left blank by default to ensure evmOS partners to set it to their respective chain denominations. This is added to the different genesis states, that are used for the app as well as testing setups.

## EIP-155 Chain ID

To support replay protection in the Hex address space, we are enforcing any chain that's using the EVM module to have an EIP-155 compliant chain ID. This required change will have to be discussed with the team, specifically what ID to choose, but was for now introduced as `osmosis_9009-1` in the codebase. This was also refactored to use a `const` in a dedicated Go package, which can be refactored in another fashion or moved elsewhere if requested.

## Fork of Wasmd

We had to introduce a fork of `github.com/CosmWasm/wasmd` because it was referring to the `CacheMultiStore` type in the Cosmos SDK. In our implementation of EVM extensions it is possible to have layered smart contract calls. These layered calls are enabled with layers of caching in our EVM implementation, which is why we have introduced a `cms.Copy()` method in our Cosmos SDK fork.

If required, we could adjust our codebase to not have a strict requirement of this feature by disabling a flag for contract-on-contract calls, which would remove the need for this fork.

## Added instances of block gas meter

The `x/feemarket` module relies on the block gas meter being set on the `context` when running its `EndBlock` method. Hence, we had to add several occurrences of setting the block gas meter in tests.