### PR TITLE
feat(evm): Enable Eth encoding

### DIFF
--- a/ante/sigverify.go
+++ b/ante/sigverify.go
@@ -1,0 +1,65 @@
+package ante
+
+import (
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256r1"
+	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	evmosante "github.com/evmos/os/ante"
+	"github.com/evmos/os/crypto/ethsecp256k1"
+)
+
+var _ authante.SignatureVerificationGasConsumer = ExtendedSigVerificationGasConsumer
+
+// ExtendedSigVerificationGasConsumer is based on the default implementation of SignatureVerificationGasConsumer
+// from the Cosmos SDK and is extended to support the eth_secp256k1 public key type.
+//
+// It consumes gas for signature verification based upon the public key type.
+// The cost is fetched from the given params and is matched by the concrete type.
+//
+// TODO: Is this desired? This would add support for signing Cosmos transactions with eth_secp256k1 keys - not only EVM transactions.
+func ExtendedSigVerificationGasConsumer(
+	meter storetypes.GasMeter, sig signing.SignatureV2, params authtypes.Params,
+) error {
+	pubkey := sig.PubKey
+	switch pubkey := pubkey.(type) {
+	case *ed25519.PubKey:
+		meter.ConsumeGas(params.SigVerifyCostED25519, "ante verify: ed25519")
+		return errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "ED25519 public keys are unsupported")
+
+	case *secp256k1.PubKey:
+		meter.ConsumeGas(params.SigVerifyCostSecp256k1, "ante verify: secp256k1")
+		return nil
+
+	case *secp256r1.PubKey:
+		meter.ConsumeGas(params.SigVerifyCostSecp256r1(), "ante verify: secp256r1")
+		return nil
+
+	case multisig.PubKey:
+		multisignature, ok := sig.Data.(*signing.MultiSignatureData)
+		if !ok {
+			return fmt.Errorf("expected %T, got, %T", &signing.MultiSignatureData{}, sig.Data)
+		}
+		err := authante.ConsumeMultisignatureVerificationGas(meter, multisignature, pubkey, params, sig.Sequence)
+		if err != nil {
+			return err
+		}
+		return nil
+
+	// evmOS key support
+	case *ethsecp256k1.PubKey:
+		meter.ConsumeGas(evmosante.Secp256k1VerifyCost, "ante verify: ethsecp256k1")
+		return nil
+
+	default:
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidPubKey, "unrecognized public key type: %T", pubkey)
+	}
+}

--- a/app/app.go
+++ b/app/app.go
@@ -106,7 +106,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/version"
-	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 
@@ -115,6 +114,7 @@ import (
 	minttypes "github.com/osmosis-labs/osmosis/v26/x/mint/types"
 	protorevtypes "github.com/osmosis-labs/osmosis/v26/x/protorev/types"
 
+	osmoante "github.com/osmosis-labs/osmosis/v26/ante"
 	"github.com/osmosis-labs/osmosis/v26/app/keepers"
 	"github.com/osmosis-labs/osmosis/v26/app/upgrades"
 	v10 "github.com/osmosis-labs/osmosis/v26/app/upgrades/v10"
@@ -601,7 +601,7 @@ func NewOsmosisApp(
 		app.BankKeeper,
 		app.TxFeesKeeper,
 		app.GAMMKeeper,
-		ante.DefaultSigVerificationGasConsumer,
+		osmoante.ExtendedSigVerificationGasConsumer,
 		encodingConfig.TxConfig.SignModeHandler(),
 		app.IBCKeeper,
 		BlockSDKAnteHandlerParams{

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -4,7 +4,7 @@ import (
 	"github.com/osmosis-labs/osmosis/v26/app/keepers"
 	"github.com/osmosis-labs/osmosis/v26/app/params"
 
-	"github.com/cosmos/cosmos-sdk/std"
+	evmosenccodec "github.com/evmos/os/encoding/codec"
 )
 
 var encodingConfig params.EncodingConfig = MakeEncodingConfig()
@@ -16,8 +16,12 @@ func GetEncodingConfig() params.EncodingConfig {
 // MakeEncodingConfig creates an EncodingConfig.
 func MakeEncodingConfig() params.EncodingConfig {
 	encodingConfig := params.MakeEncodingConfig()
-	std.RegisterLegacyAminoCodec(encodingConfig.Amino)
-	std.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+
+	// NOTE: the evmOS functions also register the standard Cosmos SDK interfaces and codecs
+	evmosenccodec.RegisterLegacyAminoCodec(encodingConfig.Amino)
+	evmosenccodec.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+
 	keepers.AppModuleBasics.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+
 	return encodingConfig
 }


### PR DESCRIPTION
## Context

This PR enables using the `eth_secp256k1` encoding for transaction signing.

## Details

To register the required implementations to support the `eth_secp256k1` algorithm, it is necessary to replace the call to `sdk.RegisterInterfaces(...)` and `sdk.RegisterImplementations(...)` with the corresponding function calls from the evmOS library. This will register all default Cosmos SDK implementations as well as the Ethereum signing algorithm and other evmOS related types/interfaces.

Furthermore, we've implemented an `ExtendedSigVerificationGasConsumer` which extends the default implementation from the Cosmos SDK to also support the Ethereum signatures for signing Cosmos transactions. This is only required to enable signatures from Eth keys in the local keyring of the `osmosisd` binary, so it could also be removed again for simplicity. This would only enable Ethereum signatures to be used through the JSON-RPC API.
